### PR TITLE
Use only one rebar erl_opts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,13 +3,12 @@
 
 {require_min_otp_vsn, "R17"}.
 
-{erl_opts, [debug_info]}.
-
 %warnings_as_errors, warn_untyped_record,
 {erl_opts, [warn_export_all,
             warn_unused_import,
             {i, "include"},
-            {src_dirs, ["src"]}
+            {src_dirs, ["src"]},
+            debug_info
             ]}.
 
 {xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
I had problems with rebar3 when it found two erl_opts. The last erl_opts options is always used.

So, merging the two erl_opts fixes the problem.