### PR TITLE
Proxy protocol v2

### DIFF
--- a/include/esockd.hrl
+++ b/include/esockd.hrl
@@ -47,3 +47,23 @@
                        src_port :: inet:port_number(),
                        dst_port :: inet:port_number()}).
 
+%%------------------------------------------------------------------------------
+%% Macro definitions for Proxy-Protocol V2
+%%------------------------------------------------------------------------------
+%% Protocol signature
+-define(PROXY_PROTO_V2_SIG, <<16#0D, 16#0A, 16#0D, 16#0A, 16#00, 16#0D, 16#0A, 16#51, 16#55, 16#49, 16#54, 16#0A>>).
+
+%% Protocol Command
+-define(PC_LOCAL, 16#0).
+-define(PC_PROXY, 16#1).
+
+%% Address families
+-define(AF_UNSPEC, 16#0).
+-define(AF_INET, 16#1).
+-define(AF_INET6, 16#2).
+-define(AF_UNIX, 16#3).
+
+%% Transport protocols
+-define(TP_UNSPEC, 16#0).
+-define(TP_STREAM, 16#1).
+-define(TP_DGRAM, 16#2).

--- a/src/esockd_proxy_proto.erl
+++ b/src/esockd_proxy_proto.erl
@@ -68,9 +68,73 @@ parse(?PROXY_PROTO_V1, Sock, Timeout) ->
             {error, proxy_proto_timeout}
     end;
 
-parse(?PROXY_PROTO_V2, _Sock, _Timeout) ->
-    %% TODO::
-    {error, proxy_proto_v2_unsupported}.
+parse(?PROXY_PROTO_V2, Sock, Timeout) ->
+    ProxyProtoSignature = ?PROXY_PROTO_V2_SIG,
+    case gen_tcp:recv(Sock, 0, Timeout) of
+        {ok, <<ProxyProtoSignature:12/binary, 16#2:4, ?PC_LOCAL:4, ?AF_UNSPEC:4, ?TP_UNSPEC:4, Len:16,
+            _Rest/binary>> = Data} -> %% LOCAL Command
+            Size = 16 + Len,
+            % push the received data back into Sock
+            gen_tcp:unrecv(Sock, Data),
+            % we need to consume the appropriate amount of data from Sock
+            {ok, _PPHdr} = gen_tcp:recv(Sock, Size, 10),
+            {ok, Sock};
+        {ok, <<ProxyProtoSignature:12/binary, 16#2:4, ?PC_PROXY:4, AddrFamily:4, TransProto:4, Len:16,
+            Rest/binary>> = Data} -> %% PROXY Command
+
+            PacketLen = byte_size(Data),
+            Size = 16 + Len,
+
+            if
+                PacketLen < Size ->
+                    {error, too_large_header};
+                true ->
+                    Result =
+                    case AddrFamily of
+                        ?AF_INET when Len >= 12, TransProto =:= ?TP_STREAM -> % TCP over IPv4
+                            <<SrcAddrBin:32, DstAddrBin:32, SrcPort:16, DstPort:16, _AddiBytes/binary>>
+                                = Rest,
+                            <<SrcA, SrcB, SrcC, SrcD>> = <<SrcAddrBin:32>>,
+                            <<DstA, DstB, DstC, DstD>> = <<DstAddrBin:32>>,
+                            ProxySock = #proxy_socket{inet = inet4,
+                                socket   = Sock,
+                                src_addr = {SrcA, SrcB, SrcC, SrcD},
+                                dst_addr = {DstA, DstB, DstC, DstD},
+                                src_port = SrcPort,
+                                dst_port = DstPort},
+                            {ok, ProxySock};
+                        ?AF_INET6 when Len >= 36, TransProto =:= ?TP_STREAM -> % TCP over IPv6
+                            <<SrcAddrBin:128, DstAddrBin:128, SrcPort:16, DstPort:16, _AddiBytes/binary>>
+                                = Rest,
+                            <<SrcA:16, SrcB:16, SrcC:16, SrcD:16, SrcE:16, SrcF:16, SrcG:16, SrcH:16>>
+                                = <<SrcAddrBin:128>>,
+                            <<DstA:16, DstB:16, DstC:16, DstD:16, DstE:16, DstF:16, DstG:16, DstH:16>>
+                                = <<DstAddrBin:128>>,
+                            ProxySock = #proxy_socket{inet = inet6,
+                                socket   = Sock,
+                                src_addr = {SrcA, SrcB, SrcC, SrcD, SrcE, SrcF, SrcG, SrcH},
+                                dst_addr = {DstA, DstB, DstC, DstD, DstE, DstF, DstG, DstH},
+                                src_port = SrcPort,
+                                dst_port = DstPort},
+                            {ok, ProxySock};
+                        _ -> %% unsupported protocols
+                            {ok, Sock}
+                    end,
+                    % push the received data back into Sock
+                    gen_tcp:unrecv(Sock, Data),
+                    % we need to consume the appropriate amount of data from Sock
+                    {ok, _PPHdr} = gen_tcp:recv(Sock, Size, 10),
+                    Result
+            end;
+        {ok, <<ProxyProtoSignature:12/binary, 16#2:4, PROXY:4, _Rest/binary>>} -> %% not a supported command
+            {error, {invalid_proto_cmd, PROXY}};
+        {ok, MsgInvalidFormat} ->
+            {error, {invalid_format, MsgInvalidFormat}};
+        {error,timeout} ->
+            {error, proxy_proto_timeout};
+        {error,Reason} ->
+            {error, Reason}
+    end.
 
 parse_inet($4) -> inet4;
 parse_inet($6) -> inet6.

--- a/test/pp_server.erl
+++ b/test/pp_server.erl
@@ -1,0 +1,114 @@
+%%%-----------------------------------------------------------------------------
+%%% @Copyright (C) 2014-2015, Feng Lee <feng@emqtt.io>
+%%%
+%%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%%% of this software and associated documentation files (the "Software"), to deal
+%%% in the Software without restriction, including without limitation the rights
+%%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%%% copies of the Software, and to permit persons to whom the Software is
+%%% furnished to do so, subject to the following conditions:
+%%%
+%%% The above copyright notice and this permission notice shall be included in all
+%%% copies or substantial portions of the Software.
+%%%
+%%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+%%% SOFTWARE.
+%%%-----------------------------------------------------------------------------
+%%% @doc
+%%% Proxy Protcol Echo Server.
+%%%
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(pp_server).
+
+-include("../include/esockd.hrl").
+
+-behaviour(gen_server).
+
+%% start
+-export([start/0, start/1, start/2]).
+
+%% esockd callback 
+-export([start_link/1]).
+
+%% gen_server Function Exports
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {conn}).
+
+-define(TCP_OPTIONS, [
+		binary,
+        %{buffer, 1024},
+		{reuseaddr, true},
+		{backlog, 512},
+		{nodelay, false}]).
+
+start() ->
+    start(5000).
+%% shell
+start([Port]) when is_atom(Port) ->
+    start(list_to_integer(atom_to_list(Port)));
+start(Port) when is_integer(Port) ->
+    application:start(sasl),
+    ok = esockd:start(),
+    SockOpts = [{acceptors, 32},
+                {max_clients, 1000000},
+                {sockopts, ?TCP_OPTIONS},
+                {connopts, [{proxy_protocol, 1}]}],
+    MFArgs = {?MODULE, start_link, []},
+    esockd:open(echo, Port, SockOpts, MFArgs).
+start(Port, v2) when is_integer(Port) ->
+  application:start(sasl),
+  ok = esockd:start(),
+  SockOpts = [{acceptors, 32},
+    {max_clients, 1000000},
+    {sockopts, ?TCP_OPTIONS},
+    {connopts, [{proxy_protocol, 2}]}],
+  MFArgs = {?MODULE, start_link, []},
+  esockd:open(echo, Port, SockOpts, MFArgs).
+
+start_link(Conn) ->
+	{ok, proc_lib:spawn_link(?MODULE, init, [Conn])}.
+
+init(Conn) ->
+    {ok, Conn1} = Conn:wait(),
+    io:format("Proxy Conn: ~p~n", [Conn1]),
+    Conn1:setopts([{active, once}]),
+    gen_server:enter_loop(?MODULE, [], #state{conn = Conn1}).
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({tcp, _Sock, Data}, State=#state{conn = Conn}) ->
+	{ok, PeerName} = Conn:peername(),
+	io:format("~s - ~s~n", [esockd_net:format(peername, PeerName), Data]),
+	Conn:send(Data),
+	Conn:setopts([{active, once}]),
+    {noreply, State};
+
+handle_info({tcp_error, _Sock, Reason}, State=#state{conn = _Conn}) ->
+	io:format("tcp_error: ~s~n", [Reason]),
+    {stop, {shutdown, {tcp_error, Reason}}, State};
+
+handle_info({tcp_closed, _Sock}, State=#state{conn = _Conn}) ->
+	io:format("tcp_closed~n"),
+	{stop, normal, State};
+
+handle_info(Info, State) ->
+    io:format("Unexpected Info: ~p~n", [Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.


### PR DESCRIPTION
Support for Proxy Protocol V2. For Command == 'PROXY', it only supports TCP over IPv4/IPv6.